### PR TITLE
Ensure ip_forward when deploying with the role, not when testing with…

### DIFF
--- a/tasks/system/forwarding.yml
+++ b/tasks/system/forwarding.yml
@@ -7,7 +7,7 @@
     sysctl_set: true
     state: present
     reload: true
-  when: not lookup('env', 'IN_MOLECULE') | d(true, true) | bool
+  when:  not lookup('env', 'IN_MOLECULE') | d(false, true) | bool
 
 - name: Set IPv6 forwarding in the sysctl file and reload if necessary
   sysctl:
@@ -17,5 +17,5 @@
     state: present
     reload: true
   when:
-    not lookup('env', 'IN_MOLECULE') | d(true, true) | bool
+    not lookup('env', 'IN_MOLECULE') | d(false, true) | bool
     and openvpn_ipv6_server is defined


### PR DESCRIPTION
… molecule. Closes #159

Cancels and replaces PR #4, now in the right branch to prepare upstream PR. 